### PR TITLE
Verwendung genderunspezifischer Sprache

### DIFF
--- a/index.html
+++ b/index.html
@@ -73,7 +73,7 @@
                     Da ich gefragt wurde II: Ja, ich habe <a href="https://www.patreon.com/sebastianfuhrmann" target="_blank">Patreon</a>. Ja, diese Webseite kostet Geld, insbesondere die notwendigen Newsportal-Abonnements, um News zu verifizieren. Nein, ich möchte kein Geld dafür und ich will auch nichts an dieser Seite verdienen. Man kann mich aber gerne bei anderen Projekten unterstützen.
                 </p>
 
-                <h2>Zusammengefasst: Tipps für Betreiber und Nutzer</h2>
+                <h2>Zusammengefasst: Tipps zum betreiben und nutzen</h2>
                 <p>
                     Der folgende Abschnitt stellt verschiedene Tipps zur Nutzung der Luca-App vor (ergänzend zu denen der Luca-App selbst), die sich aus vergangenen Ereignissen oder Mängeln der App ergeben haben - und die wir eigentlich vonseiten der Luca-Macher erwartet hätten. Die Liste ist nicht abschließend und wird immer wieder ergänzt. Um sie möglichst kurz zu halten, haben wir auf eine Referenz zu den entsprechenden Ereignissen verzichtet; diese sind aber unten nachlesbar.
                 </p>
@@ -81,7 +81,7 @@
                     <div class="accordion-item">
                         <h2 class="accordion-header" id="headingVenue">
                             <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseVenue" aria-expanded="false" aria-controls="collapseVenue">
-                                <b>Ich bin Location-Betreiber (Restaurant, Veranstaltung, usw.)...</b>
+                                <b>Ich bin betreibe eine Location (Restaurant, Veranstaltung, usw.)...</b>
                             </button>
                         </h2>
                         <div id="collapseVenue" class="accordion-collapse collapse" aria-labelledby="headingVenue" data-bs-parent="#accordionSummary">
@@ -104,16 +104,16 @@
                                         Beides ermöglicht es fremdem/entfernten Menschen (wie auch beim Veröffentlichen von QR-Codes), Gäste bei Deiner Location einzuchecken. Teilweise waren Scanner- und Kontaktformular-URLs via Google auffindbar, weil Vereine sie öffentlich auf ihrer Webseite posteten. 
                                         <small>
                                             <ul>
-                                                <li><a href="#2021-03-24_incident_Schwachstelle-Scanner-URLs-offen-Nutzer-im-Namen-von-Locations-eincheckbar-Auslastung-in-Echtzeit-auslesbar">Schwachstelle: Scanner-URLs offen, Nutzer im Namen von Locations eincheckbar, Auslastung in Echtzeit auslesbar</a></li>
+                                                <li><a href="#2021-03-24_incident_Schwachstelle-Scanner-URLs-offen-Nutzer-im-Namen-von-Locations-eincheckbar-Auslastung-in-Echtzeit-auslesbar">Schwachstelle: Scanner-URLs offen, NutzerInnen im Namen von Locations eincheckbar, Auslastung in Echtzeit auslesbar</a></li>
                                             </ul>
                                         </small>
                                     </li>
                                     <li>
-                                        <b>Betreiberschlüssel für Kontaktdaten sicher aufbewahren</b><br>
-                                        Die Luca-App wälzt eine wichtige Verantwortung an Location-Betreiber ab: Damit die Kontaktdaten später beim Gesundheitsamt entschlüsselt werden können, wird im Infektionsfall auch der Betreiberschlüssel benötigt. Der wird in den meisten Fällen von der Luca-App nur beim Erstellen der Location gebraucht, dann selten abgefragt - <b>spielt aber auch später eine große Rolle!</b>. Achte daher darauf, dass Du den Schlüssel sicher aufbewahrst, ihn nicht verlierst - und er zu den erstellten QR-Codes passt.
+                                        <b>Betriebsschlüssel ("Betreiberschlüssel" in der App) für Kontaktdaten sicher aufbewahren</b><br>
+                                        Die Luca-App wälzt eine wichtige Verantwortung an Menschen ab, die eine Location betreiben, ab: Damit die Kontaktdaten später beim Gesundheitsamt entschlüsselt werden können, wird im Infektionsfall auch der Betriebsschlüssel benötigt. Der wird in den meisten Fällen von der Luca-App nur beim Erstellen der Location gebraucht, dann selten abgefragt - <b>spielt aber auch später eine große Rolle!</b>. Achte daher darauf, dass Du den Schlüssel sicher aufbewahrst, ihn nicht verlierst - und er zu den erstellten QR-Codes passt.
                                         <small>
                                             <ul>
-                                                <li><a href="#2021-08-09_probleme_Corona-Fall-bei-einer-weiteren-Veranstaltung-in-Bad-Doberan-der-Kreis-Rostock-und-nicht-entschlsselbare-Luca-Daten">Fall im LK Rostock: Betreiberschlüssel verloren, Daten nicht entschlüsselbar</a></li>
+                                                <li><a href="#2021-08-09_probleme_Corona-Fall-bei-einer-weiteren-Veranstaltung-in-Bad-Doberan-der-Kreis-Rostock-und-nicht-entschlsselbare-Luca-Daten">Fall im LK Rostock: Betriebsschlüssel verloren, Daten nicht entschlüsselbar</a></li>
                                             </ul>
 
                                         </small>
@@ -133,7 +133,7 @@
                                     </li>
                                     <li>
                                         <b>Du brauchst keinen (physischen) QR-Code-Scanner</b><br>
-                                        Dein Smartphone bzw. das Deiner Mitarbeiter tut es auch (aber wie gesagt: Scanner-URL geheimhalten). QR-Codes musst Du dann scannen, wenn Gäste mit einem Luca-Schlüsselanhänger kommen oder Du keinen QR-Code aushängen magst. Die Scanner-URL findest Du im Luca-Webinterface.<br>
+                                        Dein Smartphone bzw. das Deiner Mitarbeitenden tut es auch (aber wie gesagt: Scanner-URL geheimhalten). QR-Codes musst Du dann scannen, wenn Gäste mit einem Luca-Schlüsselanhänger kommen oder Du keinen QR-Code aushängen magst. Die Scanner-URL findest Du im Luca-Webinterface.<br>
                                         <small>
                                             <ul>
                                                 <li><a href="#2021-10-05_news_Oldenburger-Mnsterland-Der-Luca-Schlsselanhnger-sorgt-offenbar-fr-einige-Verwirrungen">“Oldenburger Münsterland: Der Luca-Schlüsselanhänger sorgt offenbar für einige Verwirrungen”</a></li>
@@ -152,7 +152,7 @@
                     <div class="accordion-item">
                         <h2 class="accordion-header" id="headingUser">
                             <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseUser" aria-expanded="false" aria-controls="collapseUser">
-                                <b>Ich bin App-Nutzer...</b>
+                                <b>Ich benutze die App...</b>
                             </button>
                         </h2>
                         <div id="collapseUser" class="accordion-collapse collapse" aria-labelledby="headingUser" data-bs-parent="#accordionSummary">
@@ -171,12 +171,12 @@
                                     </li>
                                     <li>
                                         <b>Mache Dir den Unterschied zwischen Luca-Schlüsselanhängern und -App bewusst</b><br>
-                                        Luca-Schlüsselanhänger sind anfällig für eine Reihe von Szenarien. Allen voran: Jeder, der den Schlüsselanhänger in die Hände bekommt, kann ihn kopieren und nutzen, da das Schlüsselmaterial statisch ist. Theoretisch könnten die Luca-App-Betreiber dann sogar auf Deine Historie und Kontaktdaten zugreifen.<br>
-                                        Außerdem: Mit einem Schlüsselanhänger kannst Du nicht auschecken. Selbst ein Location-Betreiber kann nur <i>alle</i> eingecheckten Leute auschecken, nicht individuell. Du wirst also möglicherweise 24 Stunden lang als "anwesend" gezählt, obwohl Du nur kurze Zeit anwesend warst.
+                                        Luca-Schlüsselanhänger sind anfällig für eine Reihe von Szenarien. Allen voran: Alle, die den Schlüsselanhänger in die Hände bekommen, können ihn kopieren und nutzen, da das Schlüsselmaterial statisch ist. Theoretisch könnten die Menschen, die die Luca-App betreiben, dann sogar auf Deine Historie und Kontaktdaten zugreifen.<br>
+                                        Außerdem: Mit einem Schlüsselanhänger kannst Du nicht auschecken. Selbst wer eine Location betreibt kann nur <i>alle</i> eingecheckten Leute auschecken, nicht individuell. Du wirst also möglicherweise 24 Stunden lang als "anwesend" gezählt, obwohl Du nur kurze Zeit anwesend warst.
                                         <small>
                                             <ul>
                                                 <li><a href="#2021-05-14_incident_Schwachstelle-Fremde-Schlsselanhnger-lassen-sich-einchecken-Kontaktdaten-fr-das-Gesundheitsamt-vernderbar---auch-nachtrglich">Fremde Schlüsselanhänger lassen sich einchecken, Kontaktdaten für das Gesundheitsamt veränderbar (letzteres inzwischen behoben)</a></li>
-                                                <li><a href="#2021-05-14_incident_Schwachstelle-Nexenio-hat-Zugriff-auf-Seriennummer-der-Schlsselanhnger---und-damit-auf-das-Bewegungsprofil-von-Nutzern">Nexenio hat Zugriff auf Seriennummer der Schlüsselanhänger - und damit auf das Bewegungsprofil von Nutzern</a></li>
+                                                <li><a href="#2021-05-14_incident_Schwachstelle-Nexenio-hat-Zugriff-auf-Seriennummer-der-Schlsselanhnger---und-damit-auf-das-Bewegungsprofil-von-Nutzern">Nexenio hat Zugriff auf Seriennummer der Schlüsselanhänger - und damit auf das Bewegungsprofil von NutzerInnen</a></li>
                                                 <li><a href="#2021-05-11_incident_Schwachstelle-Schlsselanhnger-knnen-nicht-entschlsselt-werden">Schlüsselanhänger konnten nicht entschlüsselt werden (inzwischen behoben)</a></li>
                                                 <li><a href="#2021-04-13_incident_Schwachstelle-LucaTrack-Historie-fr-Schlsselanhnger-auslesbar-damit-Bewegungsprofile-mglich">LucaTrack: Historie für Schlüsselanhänger auslesbar, damit Bewegungsprofile möglich (inzwischen behoben)</a></li>
                                                 <li><a href="#2021-04-04_incident_Schwachstelle-Beliebige-6-stellige-Zahl-funktioniert-als-TAN">Beliebige 6-stellige Zahl funktioniert als TAN (bei Schlüsselanhängern behoben, TAN-Verifizierung in der App lässt sich noch immer umgehen)</a></li>
@@ -235,8 +235,8 @@
                                         <ul>
                                             <li>Bei den erfassten Daten handelt es sich um anonyme, wechselnde zufällige IDs (Luca: Kontaktdaten wie Name, Adresse, ...), die bis zum Teilen eines positiven Testergebnisses dezentral auf dem eigenen Gerät (Luca: Zentral auf Servern von Luca) gespeichert werden.</li>
                                             <li>Sie unterstützt die Pandemieeindämmung direkt, indem der Warnprozess verbessert wird (Luca: "Zettelwirtschaft" wird 1:1 digitalisiert)</li>
-                                            <li>Sie entlastet Gesundheitsämter. Würden - rein hypothetisch - alle Bürger die CWA in vollem Umfang nutzen - müssten sich nur noch positiv getestete bei Gesundheitsämtern melden; die Gesundheitsämter selbst müssten keine Kontakte mehr suchen.</li>
-                                            <li>Sie nutzt <a href="https://developer.apple.com/documentation/exposurenotification" target="_blank">Apple's</a>/<a href="https://www.google.com/covid19/exposurenotifications/" target="_blank">Google's</a> Exposure Notification Framework, das den Datenschutz der Nutzer gewährleistet.</li>
+                                            <li>Sie entlastet Gesundheitsämter. Würden - rein hypothetisch - alle Menschen die CWA in vollem Umfang nutzen - müssten sich nur noch positiv getestete bei Gesundheitsämtern melden; die Gesundheitsämter selbst müssten keine Kontakte mehr suchen.</li>
+                                            <li>Sie nutzt <a href="https://developer.apple.com/documentation/exposurenotification" target="_blank">Apple's</a>/<a href="https://www.google.com/covid19/exposurenotifications/" target="_blank">Google's</a> Exposure Notification Framework, das den Datenschutz der Nutzenden gewährleistet.</li>
                                         </ul>
                                         <br>
                                     </li>
@@ -423,7 +423,7 @@
                     <td valign="top">
                         <h2 id="datenschutz">Datenschutzerklärung (Kurzfassung)</h2>
                         <ul>
-                            <li>Diese Seite erfasst keinerlei Daten ihrer Besucher. Wir schreiben keine Cookies und auch keine Server-Logs, die Sie als Besucher identifizieren könnten.</li>
+                            <li>Diese Seite erfasst keinerlei Daten ihrer BesucherInnen. Wir schreiben keine Cookies und auch keine Server-Logs, die Sie als BesucherIn identifizieren könnten.</li>
                             <li>Wenn Sie uns eine E-Mail schreiben, dann erhalten wir die Daten, die Sie in dieser E-Mail angeben.</li>
                             <li>Die Webseite wird auf einem gemieteten Server bei der Hetzner GmbH (Produkt: Hetzner Cloud Server) gehostet. Auf diesem Server sind Logging etc. abgeschaltet, theoretisch wäre es aber technisch möglich, dass ein Hoster Transportdaten (z.B. IP-Adresse) loggt.</li>
                             <li>Wir verlinken auf <b>externe Webseiten</b>, auf die wir keinen Einfluss haben. Auch nicht auf die dortige Datenerfassung. Es gilt die dortige Datenschutzerklärung.</li>
@@ -539,7 +539,7 @@
                             
                             <h4>Hinweis zur Datenweitergabe in die USA und sonstige Drittstaaten</h4>
                             <p>
-                                Wir verwenden unter anderem Tools von Unternehmen mit Sitz in den USA oder sonstigen datenschutzrechtlich nicht sicheren Drittstaaten. Wenn diese Tools aktiv sind, können Ihre personenbezogene Daten in diese Drittstaaten übertragen und dort verarbeitet werden. Wir weisen darauf hin, dass in diesen Ländern kein mit der EU vergleichbares Datenschutzniveau garantiert werden kann. Beispielsweise sind US-Unternehmen dazu verpflichtet, personenbezogene Daten an Sicherheitsbehörden herauszugeben, ohne dass Sie als Betroffener hiergegen gerichtlich vorgehen könnten. Es kann daher nicht ausgeschlossen werden, dass US-Behörden (z.&nbsp;B. Geheimdienste) Ihre auf US-Servern befindlichen Daten zu Überwachungszwecken verarbeiten, auswerten und dauerhaft speichern. Wir haben auf diese Verarbeitungstätigkeiten keinen Einfluss.
+                                Wir verwenden unter anderem Tools von Unternehmen mit Sitz in den USA oder sonstigen datenschutzrechtlich nicht sicheren Drittstaaten. Wenn diese Tools aktiv sind, können Ihre personenbezogene Daten in diese Drittstaaten übertragen und dort verarbeitet werden. Wir weisen darauf hin, dass in diesen Ländern kein mit der EU vergleichbares Datenschutzniveau garantiert werden kann. Beispielsweise sind US-Unternehmen dazu verpflichtet, personenbezogene Daten an Sicherheitsbehörden herauszugeben, ohne dass Sie als Betroffene Person hiergegen gerichtlich vorgehen könnten. Es kann daher nicht ausgeschlossen werden, dass US-Behörden (z.&nbsp;B. Geheimdienste) Ihre auf US-Servern befindlichen Daten zu Überwachungszwecken verarbeiten, auswerten und dauerhaft speichern. Wir haben auf diese Verarbeitungstätigkeiten keinen Einfluss.
                             </p>
                             
                             <h4>Widerruf Ihrer Einwilligung zur Datenverarbeitung</h4>
@@ -621,16 +621,16 @@
                             <h3>6. Plugins und Tools</h3>
                             <h4>YouTube mit erweitertem Datenschutz</h4>
                             <p>
-                                Diese Website bindet Videos der YouTube ein. Betreiber der Seiten ist die Google Ireland Limited (&bdquo;Google&ldquo;), Gordon House, Barrow Street, Dublin 4, Irland.
+                                Diese Website bindet Videos der YouTube ein. Betrieben werden die Seiten von der Google Ireland Limited (&bdquo;Google&ldquo;), Gordon House, Barrow Street, Dublin 4, Irland.
                             </p>
                             <p>
-                                Wir nutzen YouTube im erweiterten Datenschutzmodus. Dieser Modus bewirkt laut YouTube, dass YouTube keine Informationen über die Besucher auf dieser Website speichert, bevor diese sich das Video ansehen. Die Weitergabe von Daten an YouTube-Partner wird durch den erweiterten Datenschutzmodus hingegen nicht zwingend ausgeschlossen. So stellt YouTube &ndash; unabhängig davon, ob Sie sich ein Video ansehen &ndash; eine Verbindung zum Google DoubleClick-Netzwerk her.
+                                Wir nutzen YouTube im erweiterten Datenschutzmodus. Dieser Modus bewirkt laut YouTube, dass YouTube keine Informationen über die Besuchenden auf dieser Website speichert, bevor diese sich das Video ansehen. Die Weitergabe von Daten an YouTube-PartnerInnen wird durch den erweiterten Datenschutzmodus hingegen nicht zwingend ausgeschlossen. So stellt YouTube &ndash; unabhängig davon, ob Sie sich ein Video ansehen &ndash; eine Verbindung zum Google DoubleClick-Netzwerk her.
                             </p>
                             <p>
                                 Sobald Sie ein YouTube-Video auf dieser Website starten, wird eine Verbindung zu den Servern von YouTube hergestellt. Dabei wird dem YouTube-Server mitgeteilt, welche unserer Seiten Sie besucht haben. Wenn Sie in Ihrem YouTube-Account eingeloggt sind, ermöglichen Sie YouTube, Ihr Surfverhalten direkt Ihrem persönlichen Profil zuzuordnen. Dies können Sie verhindern, indem Sie sich aus Ihrem YouTube-Account ausloggen.
                             </p>
                             <p>
-                                Des Weiteren kann YouTube nach Starten eines Videos verschiedene Cookies auf Ihrem Endgerät speichern oder vergleichbare Wiedererkennungstechnologien (z.&nbsp;B. Device-Fingerprinting) einsetzen. Auf diese Weise kann YouTube Informationen über Besucher dieser Website erhalten. Diese Informationen werden u. a. verwendet, um Videostatistiken zu erfassen, die Anwenderfreundlichkeit zu verbessern und Betrugsversuchen vorzubeugen.</p> <p>Gegebenenfalls können nach dem Start eines YouTube-Videos weitere Datenverarbeitungsvorgänge ausgelöst werden, auf die wir keinen Einfluss haben.</p> <p>Die Nutzung von YouTube erfolgt im Interesse einer ansprechenden Darstellung unserer Online-Angebote. Dies stellt ein berechtigtes Interesse im Sinne von Art. 6 Abs. 1 lit. f DSGVO dar. Sofern eine entsprechende Einwilligung abgefragt wurde, erfolgt die Verarbeitung ausschließlich auf Grundlage von Art. 6 Abs. 1 lit. a DSGVO; die Einwilligung ist jederzeit widerrufbar.
+                                Des Weiteren kann YouTube nach Starten eines Videos verschiedene Cookies auf Ihrem Endgerät speichern oder vergleichbare Wiedererkennungstechnologien (z.&nbsp;B. Device-Fingerprinting) einsetzen. Auf diese Weise kann YouTube Informationen über Besucher dieser Website erhalten. Diese Informationen werden u. a. verwendet, um Videostatistiken zu erfassen, die AnwenderInnenfreundlichkeit zu verbessern und Betrugsversuchen vorzubeugen.</p> <p>Gegebenenfalls können nach dem Start eines YouTube-Videos weitere Datenverarbeitungsvorgänge ausgelöst werden, auf die wir keinen Einfluss haben.</p> <p>Die Nutzung von YouTube erfolgt im Interesse einer ansprechenden Darstellung unserer Online-Angebote. Dies stellt ein berechtigtes Interesse im Sinne von Art. 6 Abs. 1 lit. f DSGVO dar. Sofern eine entsprechende Einwilligung abgefragt wurde, erfolgt die Verarbeitung ausschließlich auf Grundlage von Art. 6 Abs. 1 lit. a DSGVO; die Einwilligung ist jederzeit widerrufbar.
                             </p>
                             <p>
                                 Weitere Informationen über Datenschutz bei YouTube finden Sie in deren Datenschutzerklärung unter: <a href="https://policies.google.com/privacy?hl=de" target="_blank" rel="noopener noreferrer">https://policies.google.com/privacy?hl=de</a>.
@@ -641,13 +641,13 @@
                                 Diese Website nutzt Plugins des Videoportals Vimeo. Anbieter ist die Vimeo Inc., 555 West 18th Street, New York, New York 10011, USA.
                             </p>
                             <p>
-                                Wenn Sie eine unserer mit Vimeo-Videos ausgestatteten Seiten besuchen, wird eine Verbindung zu den Servern von Vimeo hergestellt. Dabei wird dem Vimeo-Server mitgeteilt, welche unserer Seiten Sie besucht haben. Zudem erlangt Vimeo Ihre IP-Adresse. Wir haben Vimeo jedoch so eingestellt, dass Vimeo Ihre Nutzeraktivitäten nicht nachverfolgen und keine Cookies setzen wird.
+                                Wenn Sie eine unserer mit Vimeo-Videos ausgestatteten Seiten besuchen, wird eine Verbindung zu den Servern von Vimeo hergestellt. Dabei wird dem Vimeo-Server mitgeteilt, welche unserer Seiten Sie besucht haben. Zudem erlangt Vimeo Ihre IP-Adresse. Wir haben Vimeo jedoch so eingestellt, dass Vimeo Ihre Nutzungsaktivitäten nicht nachverfolgen und keine Cookies setzen wird.
                             </p>
                             <p>
                                 Die Nutzung von Vimeo erfolgt im Interesse einer ansprechenden Darstellung unserer Online-Angebote. Dies stellt ein berechtigtes Interesse im Sinne des Art. 6 Abs. 1 lit. f DSGVO dar. Sofern eine entsprechende Einwilligung abgefragt wurde, erfolgt die Verarbeitung ausschließlich auf Grundlage von Art. 6 Abs. 1 lit. a DSGVO; die Einwilligung ist jederzeit widerrufbar.
                             </p>
                             <p>
-                                Die Datenübertragung in die USA wird auf die Standardvertragsklauseln der EU-Kommission sowie nach Aussage von Vimeo auf &bdquo;berechtigte Geschäftsinteressen&ldquo; gestützt. Details finden Sie hier: <a href="https://vimeo.com/privacy" target="_blank" rel="noopener noreferrer">https://vimeo.com/privacy</a>.</p> <p>Weitere Informationen zum Umgang mit Nutzerdaten finden Sie in der Datenschutzerklärung von Vimeo unter: <a href="https://vimeo.com/privacy" target="_blank" rel="noopener noreferrer">https://vimeo.com/privacy</a>.
+                                Die Datenübertragung in die USA wird auf die Standardvertragsklauseln der EU-Kommission sowie nach Aussage von Vimeo auf &bdquo;berechtigte Geschäftsinteressen&ldquo; gestützt. Details finden Sie hier: <a href="https://vimeo.com/privacy" target="_blank" rel="noopener noreferrer">https://vimeo.com/privacy</a>.</p> <p>Weitere Informationen zum Umgang mit NutzerInnendaten finden Sie in der Datenschutzerklärung von Vimeo unter: <a href="https://vimeo.com/privacy" target="_blank" rel="noopener noreferrer">https://vimeo.com/privacy</a>.
                             </p>
                             <p>Quelle: <a href="https://www.e-recht24.de">eRecht24</a></p>
                         </div>


### PR DESCRIPTION
Punkte, die ich noch zur Diskussion sehe:
- (z.B. Z. 96, 104, 136) ist "Gäste" genderspezifisch? ich bin mir jedes Mal neu unsicher
- (z.B. Z. 112, 114) ist "Betriebsschlüssel" wie im PullRequest benutzt ein passender Begriff für das, worum es geht? Ich bin hier auf die Meinung von Menschen mit Luca-Erfahrung angewiesen, denke aber, dass selbst wenn die Luca-App genderspezifisch kommuniziert, das hier vermieden werden kann und sollte
- (z.B. Z. 452, 507) der in "(Webseiten-)Betreiber" benutzte Singular legt nahe, dass es sich um eine einzelne Person handelt, die hier auch mit ihrer Geschlechtsidentität auftreten möchte. Da mir beim lesen aber nicht eindeutig war, dass diese Frage bei der Formulierung gestellt wurde, sowie sichergestellt ist, dass der Singular der Absicht der veröffentlichten Realität entspricht, liste ich es hier der Vollständigkeit halber
- (Z. 491ff) ist "Hoster" als generisch maskuline Formulierung a) zeitgemäß und b) im Angesichts einer Firma grammatikalisch korrekt? 

Ansonsten Danke für die Arbeit und dafür, dass es so wenig Aufwand ist, die Änderungen ans Ziel zu bringen.
Und in einer persönlichen Notiz Danke für ein Beispiel der Verwendung von OSM-Daten mit eigenen Daten, ich wollte da auch mal was machen und vielleicht schau ich mir das hier nochmal genauer an :)